### PR TITLE
修改綁定成功時，所發放的優惠券與後台發放一致、點擊帳號綁定tab中的帳號會直接跳去優惠券頁面、改帳號綁定tab名稱、優惠卷的錯字、在帳號管…

### DIFF
--- a/src/components/account-management/AccountBinding.vue
+++ b/src/components/account-management/AccountBinding.vue
@@ -1,5 +1,5 @@
 <template>
-  <!-- 帳號綁定頁面 -->
+  <!-- 帳號一覽頁面 -->
   <div class="account_page">
     <!-- 標題區 -->
     <div class="account_title">
@@ -12,9 +12,9 @@
         <!-- 帳號 -->
         <div class="account_item"
              v-for="student in students"
-             :class="{'login-student': getCurrentStudentCard === student.studentCard}">
-          <router-link
-              :to="`/profile/${lineUserId}/${student.studentCard}`">
+             :class="{'login-student': getCurrentStudentCard === student.studentCard}"
+             @click="$emit('reset-to-coupons')">
+          <router-link :to="`/profile/${lineUserId}/${student.studentCard}`">
             <!-- 圖片 -->
             <div class="item_img">
               <img :src="student.defPic">
@@ -28,12 +28,6 @@
               <div class="content_item">
                 <span>學號:</span>{{ student.studentCard }}
               </div>
-            </div>
-            <!-- 優惠券數量 -->
-            <div class="item_count">
-              <span>
-                {{ calculateCouponsCount(student) }}
-              </span>
             </div>
           </router-link>
         </div>
@@ -66,10 +60,6 @@ export default {
   },
 
   methods: {
-    calculateCouponsCount(student) {
-      return student.coupons.filter(coupon => !this.isDeadLine(coupon.date.disable)).length
-    },
-
     goToLineBindingPage() {
       // 0 的原因是 line binding的create階段 若有綁定過會進行下一步的動作，因此回到0 即可
       this.resetStepAction()
@@ -93,7 +83,7 @@ export default {
 </script>
 
 <style lang="less" scoped>
-/* 帳號綁定頁面 */
+/* 帳號一覽頁面 */
 .account_page {
 
 }

--- a/src/components/account-management/Coupons.vue
+++ b/src/components/account-management/Coupons.vue
@@ -3,7 +3,7 @@
     <div v-if="!isClickCouponDetail">
       <!-- 標題區 -->
       <div class="account_title">
-        <h1> 優惠卷專區 </h1>
+        <h1> 優惠券專區 </h1>
       </div>
 
       <!-- 頁籤 -->
@@ -161,11 +161,8 @@ export default {
 
   async created() {
     const currentStudentCard = this.getCurrentStudentCard
-    const filterCoupons = this.students.filter(student => student.studentCard === currentStudentCard)
-
-    if (filterCoupons.length > 0) {
-      this.coupons = filterCoupons[0].coupons
-    }
+    const coupons = await this.searchCouponListWithStudentCard(currentStudentCard)
+    this.coupons = coupons
 
     // 沒有if判斷 console會報錯
     if (typeof this.coupons === 'object') {

--- a/src/components/coupon/CouponDetail.vue
+++ b/src/components/coupon/CouponDetail.vue
@@ -7,7 +7,7 @@
     </div>
     <!-- 優惠碼 -->
     <div class="couponarea">
-      <span> 優惠卷: </span>
+      <span> 優惠券: </span>
       <div class="coupon_code" @click="copyToClipboard">
         <p>
           <!-- 折扣碼:  -->

--- a/src/components/line-binding/result/LineBindingSuccess.vue
+++ b/src/components/line-binding/result/LineBindingSuccess.vue
@@ -42,7 +42,7 @@
                         <mu-paper>
                           <!-- 優惠標題 -->
                           <div class="coupon_tit">
-                            <p> 新手綁定優惠方案 </p>
+                            <p> {{ coupon.name }} </p>
                             <!-- 日期 -->
                             <div class="coupon_date">
                               <p>日期:</p>{{ formatDate(coupon.date.enable) }}
@@ -79,7 +79,7 @@
         </mu-col>
       </mu-row>
       <mu-row class="no-coupon" v-else>
-        <h1> 目前沒有優惠卷 </h1>
+        <h1> 目前沒有優惠券 </h1>
       </mu-row>
     </article>
 
@@ -127,12 +127,12 @@ export default {
     const studentCard = this.student.studentCard
     try {
       // 處理優惠券
-      const coupons = await this.searchLineCouponListWithStudentCard(studentCard)
+      const coupons = await this.searchCouponListWithStudentCard(studentCard)
       this.couponCount = Object.keys(coupons).length
 
       for (let i = 0; i < this.couponCount; i++) {
         const coupon = coupons[i]
-        if (!this.isDeadLine(coupon.date.disable)) {
+        if (!this.isDeadLine(coupon.date.disable) && coupon.times > 0) {
           this.coupons.push(coupon)
         }
       }

--- a/src/views/LineBinding.vue
+++ b/src/views/LineBinding.vue
@@ -74,7 +74,7 @@ export default {
         this.student.studentCards = studentCards
         this.isAlreadyBinding = true
         this.handleNext()
-        // 當綁定過身份後 導到profile，若在profile那點擊帳號綁定，則不跳轉
+        // 當綁定過身份後 導到profile，若在profile那點擊帳號一覽，則不跳轉
         if (!this.continueBinding) {
           await this.$router.replace(`/profile/${this.lineUserId}/${this.student.studentCards[0]}`)
         }

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -1,7 +1,7 @@
 <template>
   <section id="profile" v-if="isInitial">
 
-    <AccountBinding v-if="currentTab === 'accountBinding'"></AccountBinding>
+    <AccountBinding v-if="currentTab === 'accountBinding'" @reset-to-coupons="currentTab = 'coupons'"></AccountBinding>
     <Coupons v-if="currentTab === 'coupons'"></Coupons>
     <PersonalProfile v-if="currentTab === 'personalProfile'"></PersonalProfile>
 
@@ -13,14 +13,14 @@
           <mu-button class="item_button"
             @click="isStudent ? null : currentTab = 'accountBinding'"
             :class="{selected: currentTab === 'accountBinding'}">
-            帳號綁定
+            帳號一覽
           </mu-button>
         </div>
         <div class="item">
           <mu-button class="item_button"
             @click="currentTab = 'coupons'"
             :class="{selected: currentTab === 'coupons'}">
-            優惠卷
+            優惠券
           </mu-button>
         </div>
         <div class="item">
@@ -54,7 +54,7 @@ export default {
       lineUserId: this.$route.params.specificLineUser,
       currentStudentCard: this.$route.params.studentCard,
       isStudent: false,
-      // 讓身份是學生時，帳號綁定上的css做出的遮罩效果，在畫面一宣染就遮住的同步動作
+      // 讓身份是學生時，帳號一覽上的css做出的遮罩效果，在畫面一宣染就遮住的同步動作
       isInitial: false
     }
   },
@@ -62,19 +62,34 @@ export default {
   async created() {
     try {
       await this.$store.dispatch('common/initStudentsWithLineUser', this.lineUserId)
-      for (let i = 0; i < this.students.length; i++) {
-        const studentCard = this.students[i].studentCard
-        const coupons = await this.searchCouponListWithStudentCard(studentCard)
-        await this.$set(this.students[i], 'coupons', coupons)
+      let currentStudentExists = false
+
+      for (let student of this.students) {
+        if (student.studentCard === this.currentStudentCard) {
+          currentStudentExists = true
+          break
+        }
       }
 
-      if (this.students.length > 0) {
-        // 按照 createTime 排序，確保取的是一開始綁定的身份
-        const sortedStudents = this.students
-            .sort((studentA, studentB) => dayjs(studentA.createTime).diff(dayjs(studentB.createTime),'second'))
-        this.isStudent = sortedStudents[0].authentications[0].role.toLowerCase() !== 'parent'
+      if (currentStudentExists) {
+        for (let i = 0; i < this.students.length; i++) {
+          const studentCard = this.students[i].studentCard
+          const coupons = await this.searchCouponListWithStudentCard(studentCard)
+          await this.$set(this.students[i], 'coupons', coupons)
+        }
+
+        if (this.students.length > 0) {
+          // 按照 createTime 排序，確保取的是一開始綁定的身份
+          const sortedStudents = this.students
+              .sort((studentA, studentB) => dayjs(studentA.createTime).diff(dayjs(studentB.createTime), 'second'))
+          this.isStudent = sortedStudents[0].authentications[0].role.toLowerCase() !== 'parent'
+        } else {
+          await this.$router.replace(`/lineBinding/${this.lineUserId}`)
+        }
+
       } else {
-        await this.$router.replace(`/lineBinding/${this.lineUserId}`)
+        alert('學生卡號不在學生清單中，請選擇欲查詢的帳號')
+        this.currentTab = 'accountBinding'
       }
       this.isInitial = true
     } catch (error) {


### PR DESCRIPTION
…理輸入不存在學號會導到帳號綁定、隱藏帳號綁定頭像旁的優惠券數量icon

fix

1. 綁定成功時，所發放的優惠券與後台發放一致
2. 點擊帳號綁定tab中的帳號會直接跳去優惠券頁面
3. 改帳號綁定tab名稱 => 帳號一覽、優惠「卷」 => 券 的錯字
4. 在帳號管理區，預設為選取剛綁定成功之帳號，但若在url中修改成不存在的學號，則會導到帳號一覽畫面
5. 隱藏帳號一覽頭像旁的優惠券數量顯示的icon